### PR TITLE
GEAR-1893 Fix slice direction flip for axial scans

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,12 +8,12 @@
     "url": "",
     "source": "https://github.com/flywheel-apps/ROI2nix",
     "cite": "",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "custom": {
-        "docker-image": "flywheel/roi2nix:0.3.2",
+        "docker-image": "flywheel/roi2nix:0.3.3",
         "gear-builder": {
             "category": "analysis",
-            "image": "flywheel/roi2nix:0.3.2"
+            "image": "flywheel/roi2nix:0.3.3"
         }
     },
     "inputs": {

--- a/run.py
+++ b/run.py
@@ -44,6 +44,8 @@ def main(context):
             # otherwise, do nothing.
             if perp_char in ["z", "y"]:
                 adjustment_matrix[:, 0] = -1 * adjustment_matrix[:, 0]
+            if perp_char == "z":  # also flip slice direction
+                adjustment_matrix[:, 2] = -1 * adjustment_matrix[:, 2]
 
         # Create an inverse of the matrix that is the closest projection onto the
         # basis unit vectors of the coordinate system of the original affine.


### PR DESCRIPTION
When ROIs were drawn on DICOMs that were acquired in the axial plane, the ROI slice direction (superior/inferior) was flipped.  This small addition fixes that.