### PR TITLE
Fix bitmasked nifti out

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,12 +8,12 @@
     "url": "",
     "source": "https://github.com/flywheel-apps/ROI2nix",
     "cite": "",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "custom": {
-        "docker-image": "flywheel/roi2nix:0.3.3",
+        "docker-image": "flywheel/roi2nix:0.3.4",
         "gear-builder": {
             "category": "analysis",
-            "image": "flywheel/roi2nix:0.3.3"
+            "image": "flywheel/roi2nix:0.3.4"
         }
     },
     "inputs": {

--- a/utils.py
+++ b/utils.py
@@ -827,8 +827,12 @@ def save_bitmasked_ROIs(
 
         # If the original file_input was an uncompressed NIfTI
         # ensure compression
-        if filename[-3:] == "nii":
+        if filename.endswith(".nii"):
             filename += ".gz"
+        elif filename.endswith(".dicom.zip"):
+            filename = filename.replace(".dicom.zip", ".nii.gz")
+        elif filename.endswith(".zip"):
+            filename = filename.replace(".zip", ".nii.gz")
 
         nib.save(all_labels_nii, op.join(context.output_dir, filename))
     else:


### PR DESCRIPTION
FIX: Nifti out for bitmasked image was not correctly detecting file extension (replacing .dicom.zip with .nii.gz, for example)